### PR TITLE
Redis 분산락을 활용한 동시성 제어

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
     implementation ("org.springframework.boot:spring-boot-starter-validation")
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.27.0'
 
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation ("org.springframework.boot:spring-boot-starter-validation")
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation 'org.redisson:redisson-spring-boot-starter:3.27.0'
+    implementation ("org.springframework.boot:spring-boot-starter-amqp")
 
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/example/demo/application/payment/PaymentFacade.java
+++ b/src/main/java/com/example/demo/application/payment/PaymentFacade.java
@@ -52,7 +52,8 @@ public class PaymentFacade {
                     criteria.toPaymentMockRequest(order.getProductTotalPrice())
             );
 
-            if (!"200".equals(mockPaymentResponse.getStatus())) {
+            //단순 테스트 용도 외부 API
+            if (!"SUCCESS".equals(mockPaymentResponse.getStatus())) {
                 log.error("결제 실패: orderId={}, status={}", criteria.getOrderId(), mockPaymentResponse.getStatus());
                 throw new RuntimeException("결제 API 실패");
             }

--- a/src/main/java/com/example/demo/config/FilterConfig.java
+++ b/src/main/java/com/example/demo/config/FilterConfig.java
@@ -1,7 +1,7 @@
 package com.example.demo.config;
 
 import com.example.demo.filter.AccessLogFilter;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,9 +10,9 @@ import org.springframework.context.annotation.Configuration;
 public class FilterConfig {
 
     @Bean
-    public FilterRegistrationBean<AccessLogFilter> accessLogFilter(ObjectMapper objectMapper) {
+    public FilterRegistrationBean<AccessLogFilter> accessLogFilter(RabbitTemplate rabbitTemplate) {
         FilterRegistrationBean<AccessLogFilter> registrationBean = new FilterRegistrationBean<>();
-        registrationBean.setFilter(new AccessLogFilter(objectMapper));
+        registrationBean.setFilter(new AccessLogFilter(rabbitTemplate));
         registrationBean.addUrlPatterns("/*");
         registrationBean.setOrder(1);
         return registrationBean;

--- a/src/main/java/com/example/demo/config/RabbitmqConfig.java
+++ b/src/main/java/com/example/demo/config/RabbitmqConfig.java
@@ -1,0 +1,61 @@
+package com.example.demo.config;
+
+import com.example.demo.support.properties.RabbitmqProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration
+public class RabbitmqConfig {
+    private final RabbitmqProperties rabbitmqProperties;
+
+    @Bean
+    public DirectExchange exchangeAccessLog() {
+        return new DirectExchange("exchange.access.log");
+    }
+
+    @Bean
+    public Queue queueAccessLogSave() {
+        return new Queue("queue.access.log.save", true);
+    }
+
+    @Bean
+    public Binding bindingMailSend(Queue queueAccessLogSave, DirectExchange exchangeAccessLog) {
+        return BindingBuilder.bind(queueAccessLogSave)
+                .to(exchangeAccessLog)
+                .with("route.access.log.save");
+    }
+
+    @Bean
+    public ConnectionFactory connectionFactory() {
+        CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+        connectionFactory.setHost(rabbitmqProperties.getHost());
+        connectionFactory.setPort(rabbitmqProperties.getPort());
+        connectionFactory.setUsername(rabbitmqProperties.getUsername());
+        connectionFactory.setPassword(rabbitmqProperties.getPassword());
+        return connectionFactory;
+    }
+
+    @Bean
+    public MessageConverter messageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory,
+                                         MessageConverter messageConverter) {
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        rabbitTemplate.setMessageConverter(messageConverter);
+        return rabbitTemplate;
+    }
+}

--- a/src/main/java/com/example/demo/config/RedisConfig.java
+++ b/src/main/java/com/example/demo/config/RedisConfig.java
@@ -1,0 +1,36 @@
+package com.example.demo.config;
+
+import com.example.demo.support.properties.RedisProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory factory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
+
+
+}

--- a/src/main/java/com/example/demo/config/RedissonConfig.java
+++ b/src/main/java/com/example/demo/config/RedissonConfig.java
@@ -1,0 +1,22 @@
+package com.example.demo.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+public class RedissonConfig {
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer().setAddress(REDISSON_HOST_PREFIX + "localhost:6379");
+        return Redisson.create(config);
+    }
+
+}

--- a/src/main/java/com/example/demo/config/RedissonConfig.java
+++ b/src/main/java/com/example/demo/config/RedissonConfig.java
@@ -1,5 +1,7 @@
 package com.example.demo.config;
 
+import com.example.demo.support.properties.RedisProperties;
+import lombok.RequiredArgsConstructor;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
@@ -8,14 +10,16 @@ import org.springframework.context.annotation.Configuration;
 
 
 @Configuration
+@RequiredArgsConstructor
 public class RedissonConfig {
 
-    private static final String REDISSON_HOST_PREFIX = "redis://";
+    private final RedisProperties redisProperties;
 
     @Bean
     public RedissonClient redissonClient() {
         Config config = new Config();
-        config.useSingleServer().setAddress(REDISSON_HOST_PREFIX + "localhost:6379");
+        String REDISSON_HOST_PREFIX = "redis://";
+        config.useSingleServer().setAddress(REDISSON_HOST_PREFIX + redisProperties.getHost()+":"+redisProperties.getPort());
         return Redisson.create(config);
     }
 

--- a/src/main/java/com/example/demo/domain/access/AccessLog.java
+++ b/src/main/java/com/example/demo/domain/access/AccessLog.java
@@ -1,0 +1,111 @@
+package com.example.demo.domain.access;
+
+import com.example.demo.filter.AccessLogRequest;
+import com.example.demo.infra.access.AccessLogConsumerCommand;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "t1_access_log")
+public class AccessLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "access_log_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String method;
+
+    @Column(nullable = false)
+    private String uri;
+
+    private String query;
+
+    @Lob
+    private String requestBody;
+
+    @Lob
+    private String responseBody;
+
+    @Lob
+    private String headers;
+
+    private String userAgent;
+
+    @Column(name = "remote_ip")
+    private String remoteIp;
+
+    private int status;
+
+    private String threadName;
+
+    private LocalDateTime requestAt;
+
+    private LocalDateTime responseAt;
+
+    private long durationMs;
+
+    private AccessLog(String method, String uri, String query,
+                      String requestBody, String responseBody,
+                      String headers, String userAgent, String remoteIp,
+                      int status, String threadName,
+                      LocalDateTime requestAt, LocalDateTime responseAt,
+                      long durationMs) {
+        this.method = method;
+        this.uri = uri;
+        this.query = query;
+        this.requestBody = requestBody;
+        this.responseBody = responseBody;
+        this.headers = headers;
+        this.userAgent = userAgent;
+        this.remoteIp = remoteIp;
+        this.status = status;
+        this.threadName = threadName;
+        this.requestAt = requestAt;
+        this.responseAt = responseAt;
+        this.durationMs = durationMs;
+    }
+
+    public static AccessLog of(AccessLogRequest dto) {
+        return new AccessLog(
+                dto.getMethod(),
+                dto.getUri(),
+                dto.getQuery(),
+                dto.getRequestBody(),
+                dto.getResponseBody(),
+                dto.getHeaders(),
+                dto.getUserAgent(),
+                dto.getRemoteIp(),
+                dto.getStatus(),
+                dto.getThreadName(),
+                dto.getRequestAt(),
+                dto.getResponseAt(),
+                dto.getDurationMs()
+        );
+    }
+
+    public static AccessLog of(AccessLogConsumerCommand.Save save) {
+        return new AccessLog(
+                save.getMethod(),
+                save.getUri(),
+                save.getQuery(),
+                save.getRequestBody(),
+                save.getResponseBody(),
+                save.getHeaders(),
+                save.getUserAgent(),
+                save.getRemoteIp(),
+                save.getStatus(),
+                save.getThreadName(),
+                save.getRequestAt(),
+                save.getResponseAt(),
+                save.getDurationMs()
+        );
+    }
+}

--- a/src/main/java/com/example/demo/domain/access/AccessLogRepository.java
+++ b/src/main/java/com/example/demo/domain/access/AccessLogRepository.java
@@ -1,0 +1,5 @@
+package com.example.demo.domain.access;
+
+public interface AccessLogRepository {
+    void save(AccessLog accessLog);
+}

--- a/src/main/java/com/example/demo/domain/coupon/CouponRepository.java
+++ b/src/main/java/com/example/demo/domain/coupon/CouponRepository.java
@@ -6,4 +6,5 @@ public interface CouponRepository {
     Coupon save(Coupon coupon);
     Optional<Coupon> findById(long couponId);
     Optional<Coupon> findByCouponIdForLock(Long couponId);
+    Optional<Coupon> findByCouponId(Long couponId);
 }

--- a/src/main/java/com/example/demo/domain/coupon/CouponTransactionService.java
+++ b/src/main/java/com/example/demo/domain/coupon/CouponTransactionService.java
@@ -1,0 +1,32 @@
+package com.example.demo.domain.coupon;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CouponTransactionService {
+
+    private final CouponRepository couponRepository;
+    private final UserCouponRepository userCouponRepository;
+
+    @Transactional
+    public void issueWithTransaction(CouponCommand.Issue command) {
+        Long couponId = command.getCouponId();
+        Long userId = command.getUserId();
+
+        Coupon coupon = couponRepository.findByCouponId(couponId)
+                .orElseThrow(() -> new RuntimeException("coupon not found"));
+
+        coupon.use();
+        couponRepository.save(coupon);
+
+        try {
+            userCouponRepository.save(UserCoupon.issue(couponId, userId));
+        } catch (DataIntegrityViolationException e) {
+            throw new IllegalStateException("중복 발급 불가. couponId=" + couponId);
+        }
+    }
+}

--- a/src/main/java/com/example/demo/domain/payment/PaymentHistoryInfo.java
+++ b/src/main/java/com/example/demo/domain/payment/PaymentHistoryInfo.java
@@ -1,6 +1,5 @@
 package com.example.demo.domain.payment;
 
-import com.example.demo.domain.order.OrderInfo;
 import com.example.demo.infra.payment.ResTopOrderFive;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -28,6 +27,28 @@ public class PaymentHistoryInfo {
         public static List<Top5Orders> fromResList(List<ResTopOrderFive> list) {
             return list.stream()
                     .map(item -> Top5Orders.of(item.getOrderId(), item.getCount()))
+                    .toList();
+        }
+
+    }
+
+    @Getter
+    public static class Top5OrdersForCaching {
+        private final Long orderId;
+        private final Long count;
+
+        public Top5OrdersForCaching(Long orderId, Long count) {
+            this.orderId = orderId;
+            this.count = count;
+        }
+
+        public static Top5OrdersForCaching of(Long orderId, Long count) {
+            return new Top5OrdersForCaching(orderId, count);
+        }
+
+        public static List<Top5OrdersForCaching> fromResList(List<ResTopOrderFive> list) {
+            return list.stream()
+                    .map(item -> Top5OrdersForCaching.of(item.getOrderId(), item.getCount()))
                     .toList();
         }
 

--- a/src/main/java/com/example/demo/domain/payment/PaymentHistoryService.java
+++ b/src/main/java/com/example/demo/domain/payment/PaymentHistoryService.java
@@ -1,12 +1,17 @@
 package com.example.demo.domain.payment;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.example.demo.support.Utils;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import java.util.List;
+
+import static com.example.demo.infra.payment.PaymentPopularScheduler.POPULAR_PRODUCTS_KEY;
 
 @Service
 @RequiredArgsConstructor
@@ -14,6 +19,8 @@ import java.util.List;
 public class PaymentHistoryService {
 
     private final PaymentHistoryRepository paymentHistoryRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
 
     @Transactional
     public void recordPaymentHistory(PaymentHistoryCommand.Save command) {
@@ -49,5 +56,22 @@ public class PaymentHistoryService {
 
         log.error("결제 이력 저장 재시도 실패: {}", Utils.toJson(command));
     }
+
+    public List<PaymentHistoryInfo.Top5OrdersForCaching> getPopularProductsFromCache() {
+        try {
+            String json = (String) redisTemplate.opsForValue().get(POPULAR_PRODUCTS_KEY);
+            if (json == null) return List.of();
+
+            return objectMapper.readValue(
+                    json,
+                    new TypeReference<List<PaymentHistoryInfo.Top5OrdersForCaching>>() {}
+            );
+        } catch (Exception e) {
+            log.error("인기 상품 캐시 역직렬화 실패", e);
+            return List.of();
+        }
+    }
+
+
 
 }

--- a/src/main/java/com/example/demo/domain/stock/StockService.java
+++ b/src/main/java/com/example/demo/domain/stock/StockService.java
@@ -3,22 +3,40 @@ package com.example.demo.domain.stock;
 import com.example.demo.infra.stock.StockJpaRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
 public class StockService {
     private final StockJpaRepository stockRepository;
+    private final RedissonClient redissonClient;
+    private final StockTransactionService stockTransactionService;
 
-    @Transactional
     public void deductStock(StockCommand.DeductStock command) {
-        command.getProducts().forEach(product -> {
-            Stock stock = stockRepository.findWithPessimisticLock(product.getProductId()).orElseThrow(
-                    () -> new IllegalStateException("Stock does not exist")
-            );
-            stock.deduct(product.getQuantity().intValue());
-            stockRepository.save(stock);
-        });
+        String lockKey = "lock:stock:deduct";
+        RLock lock = redissonClient.getLock(lockKey);
+
+        boolean isLocked = false;
+        try {
+            isLocked = lock.tryLock(5, 3, TimeUnit.SECONDS);
+            if (!isLocked) {
+                throw new IllegalStateException("락 획득 실패: 동시 요청 과다");
+            }
+
+            stockTransactionService.deductStockWithTransaction(command);
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("락 대기 중 인터럽트 발생", e);
+        } finally {
+            if (isLocked && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
     }
 
     @Transactional

--- a/src/main/java/com/example/demo/domain/stock/StockTransactionService.java
+++ b/src/main/java/com/example/demo/domain/stock/StockTransactionService.java
@@ -1,0 +1,25 @@
+package com.example.demo.domain.stock;
+
+import com.example.demo.infra.stock.StockJpaRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StockTransactionService {
+
+    private final StockJpaRepository stockRepository;
+
+    @Transactional
+    public void deductStockWithTransaction(StockCommand.DeductStock command) {
+        command.getProducts().forEach(product -> {
+            Stock stock = stockRepository.findWithPessimisticLock(product.getProductId())
+                    .orElseThrow(() -> new IllegalStateException("재고가 존재하지 않습니다."));
+
+            stock.deduct(product.getQuantity().intValue());
+            stockRepository.save(stock);
+        });
+    }
+
+}

--- a/src/main/java/com/example/demo/filter/AccessLogFilter.java
+++ b/src/main/java/com/example/demo/filter/AccessLogFilter.java
@@ -1,16 +1,16 @@
 package com.example.demo.filter;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.example.demo.support.Utils;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.stream.Collectors;
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class AccessLogFilter implements Filter {
 
-    private final ObjectMapper objectMapper;
+    private final RabbitTemplate rabbitTemplate;
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
@@ -29,31 +29,35 @@ public class AccessLogFilter implements Filter {
         ContentCachingResponseWrapper res = new ContentCachingResponseWrapper((HttpServletResponse) response);
         LocalDateTime requestAt = LocalDateTime.now();
 
-
         chain.doFilter(req, res);
 
         LocalDateTime responseAt = LocalDateTime.now();
 
+        String requestBody = new String(req.getContentAsByteArray(), StandardCharsets.UTF_8);
+        String responseBody = new String(res.getContentAsByteArray(), StandardCharsets.UTF_8);
 
-        AccessLogRequest accessLog = AccessLogRequest.builder()
-                .method(req.getMethod())
-                .uri(req.getRequestURI())
-                .query(req.getQueryString())
-                .requestBody(new String(req.getContentAsByteArray(), StandardCharsets.UTF_8))
-                .responseBody(new String(res.getContentAsByteArray(), StandardCharsets.UTF_8))
-                .headers(Collections.list(req.getHeaderNames()).stream()
-                        .collect(Collectors.toMap(h -> h, req::getHeader))
-                        .toString())
-                .userAgent(req.getHeader("User-Agent"))
-                .remoteIp(AccessLogRequest.extractClientIp(req))
-                .status(res.getStatus())
-                .threadName(Thread.currentThread().getName())
-                .requestAt(requestAt)
-                .responseAt(responseAt)
-                .durationMs(Duration.between(requestAt, responseAt).toMillis())
-                .build();
+        String headers = Collections.list(req.getHeaderNames()).stream()
+                .collect(Collectors.toMap(h -> h, req::getHeader))
+                .toString();
 
-        log.info("📋 AccessLog: {}", objectMapper.writeValueAsString(accessLog));
+        AccessLogRequest accessLog = AccessLogRequest.of(
+                req.getMethod(),
+                req.getRequestURI(),
+                req.getQueryString(),
+                requestBody,
+                responseBody,
+                headers,
+                req.getHeader("User-Agent"),
+                AccessLogRequest.extractClientIp(req),
+                res.getStatus(),
+                Thread.currentThread().getName(),
+                requestAt,
+                responseAt
+        );
+
+
+        rabbitTemplate.convertAndSend(accessLog.toCommand());
         res.copyBodyToResponse();
+
     }
 }

--- a/src/main/java/com/example/demo/filter/AccessLogRequest.java
+++ b/src/main/java/com/example/demo/filter/AccessLogRequest.java
@@ -1,18 +1,18 @@
 package com.example.demo.filter;
 
+import com.example.demo.infra.access.AccessLogConsumerCommand;
 import jakarta.servlet.http.HttpServletRequest;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-import java.net.Inet6Address;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
+import java.time.Duration;
 import java.time.LocalDateTime;
 
 @Getter
-@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AccessLogRequest {
+
     private String method;
     private String uri;
     private String query;
@@ -27,13 +27,65 @@ public class AccessLogRequest {
     private LocalDateTime responseAt;
     private long durationMs;
 
+    private AccessLogRequest(String method, String uri, String query, String requestBody, String responseBody,
+                             String headers, String userAgent, String remoteIp, int status, String threadName,
+                             LocalDateTime requestAt, LocalDateTime responseAt, long durationMs) {
+        this.method = method;
+        this.uri = uri;
+        this.query = query;
+        this.requestBody = requestBody;
+        this.responseBody = responseBody;
+        this.headers = headers;
+        this.userAgent = userAgent;
+        this.remoteIp = remoteIp;
+        this.status = status;
+        this.threadName = threadName;
+        this.requestAt = requestAt;
+        this.responseAt = responseAt;
+        this.durationMs = durationMs;
+    }
+
+    public static AccessLogRequest of(String method, String uri, String query,
+                                      String requestBody, String responseBody,
+                                      String headers, String userAgent, String remoteIp,
+                                      int status, String threadName,
+                                      LocalDateTime requestAt, LocalDateTime responseAt) {
+
+        long durationMs = Duration.between(requestAt, responseAt).toMillis();
+
+        return new AccessLogRequest(
+                method, uri, query,
+                requestBody, responseBody,
+                headers, userAgent, remoteIp,
+                status, threadName,
+                requestAt, responseAt, durationMs
+        );
+    }
+
     public static String extractClientIp(HttpServletRequest request) {
         String forwarded = request.getHeader("X-Forwarded-For");
         if (forwarded != null && !forwarded.isEmpty()) {
             return forwarded.split(",")[0].trim();
         }
-
         return request.getRemoteAddr();
+    }
+
+    public AccessLogConsumerCommand.Save toCommand() {
+        return AccessLogConsumerCommand.Save.of(
+                method,
+                uri,
+                query,
+                requestBody,
+                responseBody,
+                headers,
+                userAgent,
+                remoteIp,
+                status,
+                threadName,
+                requestAt,
+                responseAt,
+                durationMs
+        );
     }
 
 }

--- a/src/main/java/com/example/demo/infra/access/AccessLogConsumerCommand.java
+++ b/src/main/java/com/example/demo/infra/access/AccessLogConsumerCommand.java
@@ -1,0 +1,54 @@
+package com.example.demo.infra.access;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AccessLogConsumerCommand {
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Save {
+        private String method;
+        private String uri;
+        private String query;
+        private String requestBody;
+        private String responseBody;
+        private String headers;
+        private String userAgent;
+        private String remoteIp;
+        private int status;
+        private String threadName;
+        private LocalDateTime requestAt;
+        private LocalDateTime responseAt;
+        private long durationMs;
+
+        public static Save of(String method, String uri, String query,
+                              String requestBody, String responseBody,
+                              String headers, String userAgent, String remoteIp,
+                              int status, String threadName,
+                              LocalDateTime requestAt, LocalDateTime responseAt,
+                              long durationMs) {
+
+            Save save = new Save();
+            save.method = method;
+            save.uri = uri;
+            save.query = query;
+            save.requestBody = requestBody;
+            save.responseBody = responseBody;
+            save.headers = headers;
+            save.userAgent = userAgent;
+            save.remoteIp = remoteIp;
+            save.status = status;
+            save.threadName = threadName;
+            save.requestAt = requestAt;
+            save.responseAt = responseAt;
+            save.durationMs = durationMs;
+            return save;
+        }
+
+    }
+}

--- a/src/main/java/com/example/demo/infra/access/AccessLogConsumerService.java
+++ b/src/main/java/com/example/demo/infra/access/AccessLogConsumerService.java
@@ -1,0 +1,31 @@
+package com.example.demo.infra.access;
+
+import com.example.demo.domain.access.AccessLog;
+import com.example.demo.support.Utils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Profile("consumer")
+public class AccessLogConsumerService {
+
+    private final AccessLogJpaRepository accessLogJpaRepository;
+
+    @RabbitListener(queues = "queue.access.log.save", concurrency = "1")
+    public void saveAccessLog(AccessLogConsumerCommand.Save command) {
+        try {
+            AccessLog accessLog = AccessLog.of(command);
+            accessLogJpaRepository.save(accessLog);
+            log.info("Save access log: {}", Utils.toJson(accessLog));
+
+        }catch (Exception e){
+            log.error("AccessLog Save error : {},{}",e.getMessage(), Utils.toJson(command));
+        }
+    }
+
+}

--- a/src/main/java/com/example/demo/infra/access/AccessLogJpaRepository.java
+++ b/src/main/java/com/example/demo/infra/access/AccessLogJpaRepository.java
@@ -1,0 +1,8 @@
+package com.example.demo.infra.access;
+
+import com.example.demo.domain.access.AccessLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AccessLogJpaRepository extends JpaRepository<AccessLog, Long> {
+
+}

--- a/src/main/java/com/example/demo/infra/access/AccessLogRepositoryImpl.java
+++ b/src/main/java/com/example/demo/infra/access/AccessLogRepositoryImpl.java
@@ -1,0 +1,18 @@
+package com.example.demo.infra.access;
+
+import com.example.demo.domain.access.AccessLog;
+import com.example.demo.domain.access.AccessLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AccessLogRepositoryImpl implements AccessLogRepository {
+
+    private final AccessLogJpaRepository accessLogJpaRepository;
+
+    @Override
+    public void save(AccessLog accessLog) {
+        accessLogJpaRepository.save(accessLog);
+    }
+}

--- a/src/main/java/com/example/demo/infra/comm/lock/CustomSpringElParser.java
+++ b/src/main/java/com/example/demo/infra/comm/lock/CustomSpringElParser.java
@@ -1,0 +1,18 @@
+package com.example.demo.infra.comm.lock;
+
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public class CustomSpringElParser {
+
+    public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        SpelExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/src/main/java/com/example/demo/infra/comm/lock/RedissonLock.java
+++ b/src/main/java/com/example/demo/infra/comm/lock/RedissonLock.java
@@ -1,0 +1,13 @@
+package com.example.demo.infra.comm.lock;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface RedissonLock {
+    String value();
+    long waitTime() default 5000L;
+    long leaseTime() default 2000L;
+
+}

--- a/src/main/java/com/example/demo/infra/comm/lock/RedissonLockAspect.java
+++ b/src/main/java/com/example/demo/infra/comm/lock/RedissonLockAspect.java
@@ -1,0 +1,51 @@
+package com.example.demo.infra.comm.lock;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class RedissonLockAspect {
+
+    private final RedissonClient redissonClient;
+
+    @Around("@annotation(com.example.demo.infra.comm.lock.RedissonLock)")
+    public void redissonLock(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        RedissonLock annotation = method.getAnnotation(RedissonLock.class);
+        String lockKey = method.getName() + CustomSpringElParser.getDynamicValue(signature.getParameterNames(), joinPoint.getArgs(), annotation.value());
+
+        RLock lock = redissonClient.getLock(lockKey);
+
+        try {
+            boolean lockable = lock.tryLock(annotation.waitTime(), annotation.leaseTime(), TimeUnit.MILLISECONDS);
+            if (!lockable) {
+                log.info("Lock 획득 실패={}", lockKey);
+                return;
+            }
+            log.info("로직 수행");
+            joinPoint.proceed();
+        } catch (InterruptedException e) {
+            log.info("에러 발생");
+            throw e;
+        } finally {
+            log.info("락 해제");
+            lock.unlock();
+        }
+
+    }
+
+}

--- a/src/main/java/com/example/demo/infra/coupon/CouponJpaRepository.java
+++ b/src/main/java/com/example/demo/infra/coupon/CouponJpaRepository.java
@@ -18,4 +18,5 @@ public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
     @Query("select c from Coupon c where c.id = :couponId")
     Optional<Coupon> findByCouponIdForLock(@Param("couponId") Long couponId);
 
+
 }

--- a/src/main/java/com/example/demo/infra/coupon/CouponRepositoryImpl.java
+++ b/src/main/java/com/example/demo/infra/coupon/CouponRepositoryImpl.java
@@ -27,4 +27,9 @@ public class CouponRepositoryImpl implements CouponRepository {
     public Optional<Coupon> findByCouponIdForLock(Long couponId) {
         return couponJpaRepository.findByCouponIdForLock(couponId);
     }
+
+    @Override
+    public Optional<Coupon> findByCouponId(Long couponId) {
+        return couponJpaRepository.findById(couponId);
+    }
 }

--- a/src/main/java/com/example/demo/infra/payment/PaymentPopularScheduler.java
+++ b/src/main/java/com/example/demo/infra/payment/PaymentPopularScheduler.java
@@ -1,0 +1,31 @@
+package com.example.demo.infra.payment;
+
+import com.example.demo.domain.payment.PaymentHistory;
+import com.example.demo.domain.payment.PaymentHistoryInfo;
+import com.example.demo.domain.payment.PaymentHistoryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentPopularScheduler {
+
+    private final PaymentHistoryService paymentHistoryService;
+    private final RedisTemplate<String,Object> redisTemplate;
+    public static final String POPULAR_PRODUCTS_KEY = "popular:top5";
+
+    @Scheduled(fixedRate = 300_000)
+    public void refreshPopularProducts(){
+        List<PaymentHistoryInfo.Top5Orders> top5 = paymentHistoryService.getTop5Orders();
+        redisTemplate.opsForValue().set(POPULAR_PRODUCTS_KEY, top5, Duration.ofMinutes(6));
+        log.info("인기 상품 캐시 갱신 완료: {}", top5);
+    }
+
+}

--- a/src/main/java/com/example/demo/support/Utils.java
+++ b/src/main/java/com/example/demo/support/Utils.java
@@ -13,27 +13,23 @@ public class Utils {
             .registerModule(new JavaTimeModule())
             .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
-    //TODO 객체 → JSON 문자열
+    // 객체 → JSON 문자열
     public static String toJson(Object obj) {
         try {
-            ObjectMapper mapper = new ObjectMapper();
-            mapper.registerModule(new JavaTimeModule());
-            mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-            return mapper.writeValueAsString(obj);
-        } catch (JsonProcessingException e) {
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(obj);
+        } catch (Exception e) {
             log.warn("JSON 직렬화 실패: {}", e.getMessage());
             return "json 직렬화 실패";
         }
     }
 
-    //TODO  JSON 문자열 → 객체
+    // JSON 문자열 → 객체
     public static <T> T fromJson(String json, Class<T> clazz) {
         try {
             return objectMapper.readValue(json, clazz);
         } catch (JsonProcessingException e) {
-            log.warn("[Utils] JSON 역직렬화 실패: {}", e.getMessage());
+            log.warn("JSON 역직렬화 실패: {}", e.getMessage());
             return null;
         }
     }
-
 }

--- a/src/main/java/com/example/demo/support/properties/RabbitmqProperties.java
+++ b/src/main/java/com/example/demo/support/properties/RabbitmqProperties.java
@@ -1,0 +1,17 @@
+package com.example.demo.support.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "spring.rabbitmq")
+public class RabbitmqProperties {
+    private String host;
+    private int port;
+    private String username;
+    private String password;
+}

--- a/src/main/java/com/example/demo/support/properties/RedisProperties.java
+++ b/src/main/java/com/example/demo/support/properties/RedisProperties.java
@@ -1,10 +1,12 @@
 package com.example.demo.support.properties;
 
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 @Getter
+@Setter
 @Component
 @ConfigurationProperties(prefix = "spring.data.redis")
 public class RedisProperties {

--- a/src/main/java/com/example/demo/support/properties/RedisProperties.java
+++ b/src/main/java/com/example/demo/support/properties/RedisProperties.java
@@ -1,0 +1,13 @@
+package com.example.demo.support.properties;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+@ConfigurationProperties(prefix = "spring.data.redis")
+public class RedisProperties {
+    private String host;
+    private int port;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,9 @@ spring:
   application:
     name: demo2
 
+  profiles:
+    active: consumer
+
   data:
     redis:
       host: localhost
@@ -19,6 +22,12 @@ spring:
     redis:
       use-key-prefix: true
       cache-null-values: true
+
+  rabbitmq:
+    host: localhost
+    port: 5672
+    username: guest
+    password: guest
 
   datasource:
     url: jdbc:mysql://localhost:3306/jmdb

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,10 +9,21 @@ spring:
   application:
     name: demo2
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      timeout: 0
+  cache:
+    type: redis
+    redis:
+      use-key-prefix: true
+      cache-null-values: true
+
   datasource:
     url: jdbc:mysql://localhost:3306/jmdb
     username: root
-    password: 12345
+    password: 1111
     driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:
       maximum-pool-size: 50  # 5 → 50 이상으로 확장


### PR DESCRIPTION
## **커밋 링크**
### Redis 분산락 동시성 제어 구현
 - 쿠폰 발급 : [e42d6c2](https://github.com/jaemin4/cleanJ/pull/6/commits/e42d6c20bfcb9001ad4e923a12e8e3f03e140f4f), [f139f79](https://github.com/jaemin4/cleanJ/pull/6/commits/f139f793ecdcfe8cc84d8c8a19f562e224dd84d8)
 - 재고 감소 : [a348486](https://github.com/jaemin4/cleanJ/pull/6/commits/a348486e155fbabba85f360972afe67f70c46715)
 - 테스트 : 기존에 비관적 락을 활용해 구현했던 Coupon과 Stock의 동시성 테스트를, 이번에는 Redis 기반 분산락으로 변경한 후에도 정상적으로 통과

### AccessLog DB 저장
- [41463e9](https://github.com/jaemin4/cleanJ/pull/6/commits/41463e9de80f38f03cc1ac6d07a00ee7e7660a9b)




