### PR TITLE
결제 이벤트 분리

### DIFF
--- a/src/main/java/com/example/demo/application/payment/ExternalPaymentEventHandler.java
+++ b/src/main/java/com/example/demo/application/payment/ExternalPaymentEventHandler.java
@@ -11,6 +11,9 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
 import static com.example.demo.support.constants.RabbitmqConstant.EXCHANGE_PAYMENT_HISTORY;
 import static com.example.demo.support.constants.RabbitmqConstant.ROUTE_PAYMENT_HISTORY_REDIS_UPDATE;
 
@@ -24,7 +27,7 @@ public class ExternalPaymentEventHandler {
     private final PaymentHistoryService paymentHistoryService;
     private final RabbitTemplate rabbitTemplate;
 
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void requestPaymentApi(PaymentEvent.RequestPaymentApi event){
         PaymentMockResponse.MockPay result = mockPaymentService.callAndValidateMockApi(
         PaymentMockRequest.Mock.of(event.getOrderId(),event.getUserId(),event.getFinalAmount()));

--- a/src/main/java/com/example/demo/application/payment/ExternalPaymentEventHandler.java
+++ b/src/main/java/com/example/demo/application/payment/ExternalPaymentEventHandler.java
@@ -1,0 +1,60 @@
+package com.example.demo.application.payment;
+
+import com.example.demo.domain.payment.PaymentHistoryCommand;
+import com.example.demo.domain.payment.PaymentHistoryService;
+import com.example.demo.infra.payment.MockPaymentService;
+import com.example.demo.infra.payment.PaymentMockRequest;
+import com.example.demo.infra.payment.PaymentMockResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import static com.example.demo.support.constants.RabbitmqConstant.EXCHANGE_PAYMENT_HISTORY;
+import static com.example.demo.support.constants.RabbitmqConstant.ROUTE_PAYMENT_HISTORY_REDIS_UPDATE;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ExternalPaymentEventHandler {
+
+    private final MockPaymentService mockPaymentService;
+    private final ApplicationEventPublisher eventPublisher;
+    private final PaymentHistoryService paymentHistoryService;
+    private final RabbitTemplate rabbitTemplate;
+
+    @EventListener
+    public void requestPaymentApi(PaymentEvent.RequestPaymentApi event){
+        PaymentMockResponse.MockPay result = mockPaymentService.callAndValidateMockApi(
+        PaymentMockRequest.Mock.of(event.getOrderId(),event.getUserId(),event.getFinalAmount()));
+
+        if (!"SUCCESS".equals(result.getStatus())) {
+            eventPublisher.publishEvent(PaymentEvent.RecoveryOrder.of(event.getOrderId()));
+            eventPublisher.publishEvent(PaymentEvent.RecoveryPayment.of(
+            event.getOrderId(), event.getUserId(), event.getCouponId(), event.getFinalAmount()));
+            throw new RuntimeException("결제 API 실패");
+        }
+
+        try{
+            paymentHistoryService.recordPaymentHistory(PaymentHistoryCommand.Save.of(event.getUserId(),
+                    event.getFinalAmount(),event.getOrderId(),result.getTransactionId(),result.getStatus()));
+        }catch (Exception e){
+            log.info("결제내역 저장 실패 : {}", e.getMessage());
+            //TODO 추가 조치 필요
+        }
+
+        try {
+            rabbitTemplate.convertAndSend(
+                    EXCHANGE_PAYMENT_HISTORY,
+                    ROUTE_PAYMENT_HISTORY_REDIS_UPDATE,
+                    event.getOrderId()
+            );
+        } catch (Exception e) {
+            log.error("Redis 랭킹 업데이트 실패: orderId={}, error={}", event.getOrderId(), e.getMessage(), e);
+            //TODO 추가 조치 필요
+        }
+
+
+    }
+}

--- a/src/main/java/com/example/demo/application/payment/PaymentCompletedEvent.java
+++ b/src/main/java/com/example/demo/application/payment/PaymentCompletedEvent.java
@@ -1,0 +1,6 @@
+package com.example.demo.application.payment;
+
+public record PaymentCompletedEvent(
+        PaymentCriteria.Payment criteria,
+        PaymentTransactionResult.Payment result
+) {}

--- a/src/main/java/com/example/demo/application/payment/PaymentEvent.java
+++ b/src/main/java/com/example/demo/application/payment/PaymentEvent.java
@@ -1,0 +1,76 @@
+package com.example.demo.application.payment;
+
+import com.example.demo.domain.order.OrderInfo;
+import com.example.demo.domain.stock.StockCommand;
+import lombok.Getter;
+
+import java.util.List;
+
+public class PaymentEvent {
+
+    @Getter
+    public static class RequestPaymentApi {
+        private final Long orderId;
+        private final Long userId;
+        private final long finalAmount;
+        private final Long couponId;
+
+
+        private RequestPaymentApi(Long orderId, Long userId, long finalAmount, Long couponId) {
+            this.orderId = orderId;
+            this.userId = userId;
+            this.finalAmount = finalAmount;
+            this.couponId = couponId;
+        }
+
+        public static RequestPaymentApi of(Long orderId, Long userId, long finalAmount, Long couponId) {
+            return new RequestPaymentApi(orderId, userId, finalAmount, couponId);
+        }
+
+    }
+
+    @Getter
+    public static class RecoveryOrder{
+        private final Long orderId;
+
+        private RecoveryOrder(Long orderId) {
+            this.orderId = orderId;
+        }
+
+        public static RecoveryOrder of(Long orderId) {
+            return new RecoveryOrder(orderId);
+        }
+
+        public StockCommand.RecoveryStock toRecoveryStockCommand(OrderInfo.GetOrderItems getOrderItems) {
+            List<StockCommand.OrderProduct> products = getOrderItems.getItems().stream()
+                    .map(item -> StockCommand.OrderProduct.of(item.getProductId(), item.getQuantity()))
+                    .toList();
+
+            return StockCommand.RecoveryStock.of(products);
+        }
+    }
+
+    @Getter
+    public static class RecoveryPayment{
+        private final Long orderId;
+        private final Long userId;
+        private final Long couponId;
+        private final long finalAmount;
+
+        private RecoveryPayment(Long orderId, Long userId, Long couponId, long finalAmount) {
+            this.orderId = orderId;
+            this.userId = userId;
+            this.couponId = couponId;
+            this.finalAmount = finalAmount;
+        }
+
+        public static RecoveryPayment of(Long orderId, Long userId, Long couponId, long finalAmount) {
+            return new RecoveryPayment(orderId, userId, couponId, finalAmount);
+        }
+
+
+    }
+
+
+
+}

--- a/src/main/java/com/example/demo/application/payment/PaymentEventHandler.java
+++ b/src/main/java/com/example/demo/application/payment/PaymentEventHandler.java
@@ -1,8 +1,16 @@
 package com.example.demo.application.payment;
 
+import com.example.demo.domain.payment.PaymentHistoryCommand;
+import com.example.demo.domain.payment.PaymentHistoryService;
+import com.example.demo.infra.payment.MockPaymentService;
+import com.example.demo.infra.payment.PaymentMockRequest;
+import com.example.demo.infra.payment.PaymentMockResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.context.event.EventListener;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.transaction.event.TransactionPhase;
@@ -14,31 +22,29 @@ import static com.example.demo.support.constants.RabbitmqConstant.*;
 public class PaymentEventHandler {
 
     private final RabbitTemplate rabbitTemplate;
+    private final PaymentEventTransaction paymentEventTransaction;
+    private final MockPaymentService mockPaymentService;
+    private final PaymentHistoryService paymentHistoryService;
 
+    @Retryable(
+            exceptionExpression = "#{exception instanceof T(java.lang.Exception)}",
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 0)
+    )
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handlePaymentCompleted(PaymentCompletedEvent event) {
-        var criteria = event.criteria();
-        var result = event.result();
-
-        try {
-            rabbitTemplate.convertAndSend(
-                    EXCHANGE_PAYMENT_HISTORY,
-                    ROUTE_PAYMENT_HISTORY_DB_SAVE,
-                    criteria.toPaymentHistoryConsumerCommand(result.getFinalAmount(), result.getTransactionId(), result.getStatus())
-            );
-            log.info("결제내역 저장 메시지 전송 성공: orderId={}", criteria.getOrderId());
-        } catch (Exception e) {
-            log.error("결제내역 저장 메시지 전송 실패: {}", e.getMessage(), e);
-        }
-
-        try {
-            rabbitTemplate.convertAndSend(
-                    EXCHANGE_PAYMENT_HISTORY,
-                    ROUTE_PAYMENT_HISTORY_REDIS_UPDATE,
-                    criteria.getOrderId()
-            );
-        } catch (Exception e) {
-            log.error("Redis 랭킹 업데이트 실패: orderId={}, error={}", criteria.getOrderId(), e.getMessage(), e);
-        }
+    public void recoveryOrder(PaymentEvent.RecoveryOrder event){
+        paymentEventTransaction.recoveryOrder(event);
     }
+
+    @Retryable(
+            exceptionExpression = "#{exception instanceof T(java.lang.Exception)}",
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 0)
+    )
+    @EventListener
+    public void recoveryPayment(PaymentEvent.RecoveryPayment event){
+        paymentEventTransaction.recoveryPayment(PaymentEvent.RecoveryPayment.of(event.getOrderId(),
+                event.getUserId(), event.getCouponId(), event.getFinalAmount()));
+    }
+
 }

--- a/src/main/java/com/example/demo/application/payment/PaymentEventHandler.java
+++ b/src/main/java/com/example/demo/application/payment/PaymentEventHandler.java
@@ -1,0 +1,44 @@
+package com.example.demo.application.payment;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.event.TransactionPhase;
+import static com.example.demo.support.constants.RabbitmqConstant.*;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentEventHandler {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlePaymentCompleted(PaymentCompletedEvent event) {
+        var criteria = event.criteria();
+        var result = event.result();
+
+        try {
+            rabbitTemplate.convertAndSend(
+                    EXCHANGE_PAYMENT_HISTORY,
+                    ROUTE_PAYMENT_HISTORY_DB_SAVE,
+                    criteria.toPaymentHistoryConsumerCommand(result.getFinalAmount(), result.getTransactionId(), result.getStatus())
+            );
+            log.info("결제내역 저장 메시지 전송 성공: orderId={}", criteria.getOrderId());
+        } catch (Exception e) {
+            log.error("결제내역 저장 메시지 전송 실패: {}", e.getMessage(), e);
+        }
+
+        try {
+            rabbitTemplate.convertAndSend(
+                    EXCHANGE_PAYMENT_HISTORY,
+                    ROUTE_PAYMENT_HISTORY_REDIS_UPDATE,
+                    criteria.getOrderId()
+            );
+        } catch (Exception e) {
+            log.error("Redis 랭킹 업데이트 실패: orderId={}, error={}", criteria.getOrderId(), e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/example/demo/application/payment/PaymentEventTransaction.java
+++ b/src/main/java/com/example/demo/application/payment/PaymentEventTransaction.java
@@ -1,0 +1,61 @@
+package com.example.demo.application.payment;
+
+import com.example.demo.domain.balance.BalanceCommand;
+import com.example.demo.domain.balance.BalanceService;
+import com.example.demo.domain.coupon.CouponCommand;
+import com.example.demo.domain.coupon.CouponService;
+import com.example.demo.domain.order.OrderInfo;
+import com.example.demo.domain.order.OrderService;
+import com.example.demo.domain.order.OrderStatus;
+import com.example.demo.domain.stock.StockService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentEventTransaction {
+
+    private final OrderService orderService;
+    private final StockService stockService;
+    private final BalanceService balanceService;
+    private final CouponService couponService;
+
+
+    @Transactional
+    public void recoveryOrder(PaymentEvent.RecoveryOrder event) {
+        try {
+            OrderInfo.GetOrder order = orderService.getOrderById(event.getOrderId());
+            if (order != null && order.getOrderStatus().equals(OrderStatus.CREATED)) {
+                log.info("주문 상태 복구 및 재고 복구 시작 : {}", order.getOrderId());
+
+                orderService.updateOrderStatus(order.getOrderId(), OrderStatus.CANCELED);
+
+                OrderInfo.GetOrderItems getOrderItems = orderService.getOrderItemByOrderId(order.getOrderId());
+                stockService.recoveryStock(event.toRecoveryStockCommand(getOrderItems));
+
+                log.info("주문 취소 및 재고 복구 완료");
+            } else {
+                log.info("이미 취소된 주문입니다. orderId={}", event.getOrderId());
+            }
+
+        } catch (Exception recoveryEx) {
+            log.error("회복 중 추가 오류 발생: {}", recoveryEx.getMessage(), recoveryEx);
+            //TODO 추가 조치 필요
+        }
+    }
+
+    @Transactional
+    public void recoveryPayment(PaymentEvent.RecoveryPayment event){
+        if(event.getCouponId() != null){
+            couponService.issue(CouponCommand.Issue.of(event.getUserId(),event.getCouponId()));
+        }
+        balanceService.charge(BalanceCommand.Charge.of(event.getUserId(),event.getFinalAmount()));
+        orderService.updateOrderStatus(event.getOrderId(), OrderStatus.CANCELED);
+    }
+
+}

--- a/src/main/java/com/example/demo/application/payment/PaymentFacade.java
+++ b/src/main/java/com/example/demo/application/payment/PaymentFacade.java
@@ -3,6 +3,7 @@ package com.example.demo.application.payment;
 import com.example.demo.support.comm.aop.DistributedLock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
 import static com.example.demo.support.constants.RabbitmqConstant.*;
@@ -19,17 +20,27 @@ public class PaymentFacade {
     public void pay(PaymentCriteria.Payment criteria) {
         PaymentTransactionResult.Payment result = paymentTransaction.processPaymentWithTransaction(criteria);
 
-        //결제내역 저장
-        rabbitTemplate.convertAndSend(
-                EXCHANGE_PAYMENT_HISTORY, ROUTE_PAYMENT_HISTORY_DB_SAVE,
-                criteria.toPaymentHistoryConsumerCommand(result.getFinalAmount(), result.getTransactionId(), result.getStatus())
-        );
+        try {
+            rabbitTemplate.convertAndSend(
+                    EXCHANGE_PAYMENT_HISTORY,
+                    ROUTE_PAYMENT_HISTORY_DB_SAVE,
+                    criteria.toPaymentHistoryConsumerCommand(result.getFinalAmount(), result.getTransactionId(), result.getStatus())
+            );
+            log.info("결제내역 저장 메시지 전송 성공: orderId={}", criteria.getOrderId());
+        } catch (Exception e) {
+            log.error("[RabbitMQ 전송 실패] 결제내역 저장 실패: orderId={}, error={}", criteria.getOrderId(), e.getMessage(), e);
+        }
 
-        //Redis 랭킹 업데이트
-        rabbitTemplate.convertAndSend(
-                EXCHANGE_PAYMENT_HISTORY, ROUTE_PAYMENT_HISTORY_REDIS_UPDATE,
-                criteria.getOrderId()
-        );
+        // Redis 랭킹 업데이트
+        try {
+            rabbitTemplate.convertAndSend(
+                    EXCHANGE_PAYMENT_HISTORY,
+                    ROUTE_PAYMENT_HISTORY_REDIS_UPDATE,
+                    criteria.getOrderId()
+            );
+        } catch (Exception e) {
+            log.error("[RabbitMQ 전송 실패] Redis 랭킹 업데이트 실패: orderId={}, error={}", criteria.getOrderId(), e.getMessage(), e);
+        }
 
     }
 

--- a/src/main/java/com/example/demo/application/payment/PaymentFacade.java
+++ b/src/main/java/com/example/demo/application/payment/PaymentFacade.java
@@ -3,7 +3,9 @@ package com.example.demo.application.payment;
 import com.example.demo.support.comm.aop.DistributedLock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
+import static com.example.demo.support.constants.RabbitmqConstant.*;
 
 @Slf4j
 @Component
@@ -11,10 +13,24 @@ import org.springframework.stereotype.Component;
 public class PaymentFacade {
 
     private final PaymentTransaction paymentTransaction;
+    private final RabbitTemplate rabbitTemplate;
 
     @DistributedLock(key = "'payment:user:' + #criteria.userId", waitTime = 3, leaseTime = 5)
     public void pay(PaymentCriteria.Payment criteria) {
-        paymentTransaction.processPaymentWithTransaction(criteria);
+        PaymentTransactionResult.Payment result = paymentTransaction.processPaymentWithTransaction(criteria);
+
+        //결제내역 저장
+        rabbitTemplate.convertAndSend(
+                EXCHANGE_PAYMENT_HISTORY, ROUTE_PAYMENT_HISTORY_DB_SAVE,
+                criteria.toPaymentHistoryConsumerCommand(result.getFinalAmount(), result.getTransactionId(), result.getStatus())
+        );
+
+        //Redis 랭킹 업데이트
+        rabbitTemplate.convertAndSend(
+                EXCHANGE_PAYMENT_HISTORY, ROUTE_PAYMENT_HISTORY_REDIS_UPDATE,
+                criteria.getOrderId()
+        );
+
     }
 
 

--- a/src/main/java/com/example/demo/application/payment/PaymentFacade.java
+++ b/src/main/java/com/example/demo/application/payment/PaymentFacade.java
@@ -3,10 +3,7 @@ package com.example.demo.application.payment;
 import com.example.demo.support.comm.aop.DistributedLock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.amqp.AmqpException;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Component;
-import static com.example.demo.support.constants.RabbitmqConstant.*;
 
 @Slf4j
 @Component
@@ -14,34 +11,10 @@ import static com.example.demo.support.constants.RabbitmqConstant.*;
 public class PaymentFacade {
 
     private final PaymentTransaction paymentTransaction;
-    private final RabbitTemplate rabbitTemplate;
 
     @DistributedLock(key = "'payment:user:' + #criteria.userId", waitTime = 3, leaseTime = 5)
     public void pay(PaymentCriteria.Payment criteria) {
-        PaymentTransactionResult.Payment result = paymentTransaction.processPaymentWithTransaction(criteria);
-
-        try {
-            rabbitTemplate.convertAndSend(
-                    EXCHANGE_PAYMENT_HISTORY,
-                    ROUTE_PAYMENT_HISTORY_DB_SAVE,
-                    criteria.toPaymentHistoryConsumerCommand(result.getFinalAmount(), result.getTransactionId(), result.getStatus())
-            );
-            log.info("결제내역 저장 메시지 전송 성공: orderId={}", criteria.getOrderId());
-        } catch (Exception e) {
-            log.error("[RabbitMQ 전송 실패] 결제내역 저장 실패: orderId={}, error={}", criteria.getOrderId(), e.getMessage(), e);
-        }
-
-        // Redis 랭킹 업데이트
-        try {
-            rabbitTemplate.convertAndSend(
-                    EXCHANGE_PAYMENT_HISTORY,
-                    ROUTE_PAYMENT_HISTORY_REDIS_UPDATE,
-                    criteria.getOrderId()
-            );
-        } catch (Exception e) {
-            log.error("[RabbitMQ 전송 실패] Redis 랭킹 업데이트 실패: orderId={}, error={}", criteria.getOrderId(), e.getMessage(), e);
-        }
-
+         paymentTransaction.processPaymentWithTransaction(criteria);
     }
 
 

--- a/src/main/java/com/example/demo/application/payment/PaymentFacade.java
+++ b/src/main/java/com/example/demo/application/payment/PaymentFacade.java
@@ -1,43 +1,20 @@
 package com.example.demo.application.payment;
 
+import com.example.demo.support.comm.aop.DistributedLock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.redisson.api.RLock;
-import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Component;
-import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class PaymentFacade {
 
-    private final RedissonClient redissonClient;
     private final PaymentTransaction paymentTransaction;
 
+    @DistributedLock(key = "'payment:user:' + #criteria.userId", waitTime = 3, leaseTime = 5)
     public void pay(PaymentCriteria.Payment criteria) {
-        String lockKey = "lock:payment:user:" + criteria.getUserId();
-        RLock lock = redissonClient.getLock(lockKey);
-        boolean isLocked = false;
-
-        try {
-            isLocked = lock.tryLock(3, 5, TimeUnit.SECONDS);
-            if (!isLocked) {
-                throw new IllegalStateException("중복 결제 요청입니다. 잠시 후 다시 시도해주세요.");
-            }
-
-            paymentTransaction.processPaymentWithTransaction(criteria);
-
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("결제 락 대기 중 인터럽트 발생", e);
-        } catch (Exception e) {
-            throw new RuntimeException("결제 처리 중 예외 발생 : " + e.getMessage());
-        } finally {
-            if (isLocked && lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
-        }
+        paymentTransaction.processPaymentWithTransaction(criteria);
     }
 
 

--- a/src/main/java/com/example/demo/application/payment/PaymentTransaction.java
+++ b/src/main/java/com/example/demo/application/payment/PaymentTransaction.java
@@ -12,8 +12,10 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
-import static com.example.demo.support.constants.RabbitmqConstant.*;
+
+import static com.example.demo.infra.payment.PaymentPopularScheduler.POPULAR_PRODUCTS_KEY;
 
 @Slf4j
 @Service
@@ -24,64 +26,50 @@ public class PaymentTransaction {
     private final MockPaymentService mockPaymentService;
     private final CouponService couponService;
     private final StockService stockService;
-    private final RabbitTemplate rabbitTemplate;
+    private final RedisTemplate<String, String> redisTemplate;
 
     @Transactional
-    public void processPaymentWithTransaction(PaymentCriteria.Payment criteria) {
+    public PaymentTransactionResult.Payment processPaymentWithTransaction(PaymentCriteria.Payment criteria) {
         OrderInfo.GetOrder order = null;
         try {
+
+            //주문 조회
             order = orderService.getOrderById(criteria.getOrderId());
             long finalAmount = order.getProductTotalPrice();
+
             if (order.getOrderStatus().equals(OrderStatus.PAID)) {
                 log.info("이미 결제된 주문입니다.");
                 throw new RuntimeException("이미 결제된 주문입니다.");
             }
-            /*
-                1. 쿠폰사용
-            */
+
+            //쿠폰사용
             if (criteria.getCouponId() != null) {
                 couponService.use(criteria.toUseCouponCommand());
                 finalAmount = couponService.calculateDiscountedAmount(finalAmount, criteria.getCouponId());
             }
 
-            /*
-                2. 포인트사용
-            */
+            // 포인트사용
             balanceService.use(criteria.toBalanceUseCommand(finalAmount));
 
-            /*
-                3. 주문상태변경
-            */
+            //주문상태변경
             orderService.updateOrderStatus(criteria.getOrderId(), OrderStatus.PAID);
 
-            /*
-                4. 외부 API 호출
-            */
+            //외부 API 호출
             PaymentMockResponse.MockPay mockPaymentResponse = mockPaymentService.callAndValidateMockApi(
-                    criteria.toPaymentMockRequest(order.getProductTotalPrice())
+                    criteria.toPaymentMockRequest(finalAmount)
             );
 
+            //API 호출 검증
             if (!"SUCCESS".equals(mockPaymentResponse.getStatus())) {
                 log.error("결제 실패: orderId={}, status={}", criteria.getOrderId(), mockPaymentResponse.getStatus());
                 throw new RuntimeException("결제 API 실패");
             }
-            /*
-                5. 결제내역 저장
-            */
-            rabbitTemplate.convertAndSend(
-                    EXCHANGE_PAYMENT_HISTORY, ROUTE_PAYMENT_HISTORY_DB_SAVE,
-                    criteria.toPaymentHistoryConsumerCommand(finalAmount, mockPaymentResponse.getTransactionId(), mockPaymentResponse.getStatus())
+
+            return PaymentTransactionResult.Payment.of(
+                    mockPaymentResponse.getTransactionId(),
+                    mockPaymentResponse.getStatus(),
+                    finalAmount
             );
-
-            /*
-                6. Redis 랭킹 업데이트
-            */
-
-            rabbitTemplate.convertAndSend(
-                    EXCHANGE_PAYMENT_HISTORY, ROUTE_PAYMENT_HISTORY_REDIS_UPDATE,
-                    criteria.getOrderId()
-            );
-
 
         } catch (Exception e) {
             log.warn("트랜잭션 내 결제 실패, 주문 상태 취소 및 재고 복구 수행");
@@ -90,12 +78,15 @@ public class PaymentTransaction {
                 if (order != null && order.getOrderStatus().equals(OrderStatus.CREATED)) {
                     log.info("주문 상태 복구 및 재고 복구 시작: orderId={}", criteria.getOrderId());
 
-                    // 1. 주문 상태 변경
+                    //주문 상태 변경
                     orderService.updateOrderStatus(criteria.getOrderId(), OrderStatus.CANCELED);
 
-                    // 2. 재고 복구
+                    //재고 복구
                     OrderInfo.GetOrderItems getOrderItems = orderService.getOrderItemByOrderId(criteria.getOrderId());
                     stockService.recoveryStock(criteria.toRecoveryStockCommand(getOrderItems));
+
+                    //쿠폰 랭킹 복구
+                   // redisTemplate.opsForZSet().incrementScore(POPULAR_PRODUCTS_KEY, productId, -1);
 
                     log.info("주문 취소 및 재고 복구 완료");
                 } else {

--- a/src/main/java/com/example/demo/application/payment/PaymentTransaction.java
+++ b/src/main/java/com/example/demo/application/payment/PaymentTransaction.java
@@ -5,14 +5,10 @@ import com.example.demo.domain.coupon.CouponService;
 import com.example.demo.domain.order.OrderInfo;
 import com.example.demo.domain.order.OrderService;
 import com.example.demo.domain.order.OrderStatus;
-import com.example.demo.domain.stock.StockService;
-import com.example.demo.infra.payment.MockPaymentService;
-import com.example.demo.infra.payment.PaymentMockResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -22,112 +18,35 @@ public class PaymentTransaction {
 
     private final OrderService orderService;
     private final BalanceService balanceService;
-    private final MockPaymentService mockPaymentService;
     private final CouponService couponService;
-    private final StockService stockService;
-    private final RedisTemplate<String, String> redisTemplate;
     private final ApplicationEventPublisher eventPublisher;
-
 
     @Transactional
     public void processPaymentWithTransaction(PaymentCriteria.Payment criteria) {
-        OrderInfo.GetOrder order = null;
         try {
-
-             /*
-                 주문 조회
-             */
-
-            order = orderService.getOrderById(criteria.getOrderId());
+            OrderInfo.GetOrder order = orderService.getOrderById(criteria.getOrderId());
             long finalAmount = order.getProductTotalPrice();
 
             if (order.getOrderStatus().equals(OrderStatus.PAID)) {
                 log.info("이미 결제된 주문입니다.");
                 throw new RuntimeException("이미 결제된 주문입니다.");
             }
-
-            /*
-                쿠폰사용
-            */
             if (criteria.getCouponId() != null) {
                 couponService.use(criteria.toUseCouponCommand());
                 finalAmount = couponService.calculateDiscountedAmount(finalAmount, criteria.getCouponId());
             }
-
-            /*
-                포인트사용
-            */
             balanceService.use(criteria.toBalanceUseCommand(finalAmount));
-
-
-            /*
-                주문상태변경
-            */
             orderService.updateOrderStatus(criteria.getOrderId(), OrderStatus.PAID);
 
-            /*
-                외부 API 호출
-            */
-            PaymentMockResponse.MockPay mockPaymentResponse = mockPaymentService.callAndValidateMockApi(
-                    criteria.toPaymentMockRequest(finalAmount)
-            );
-
-            /*
-                API 호출 검증
-            */
-            if (!"SUCCESS".equals(mockPaymentResponse.getStatus())) {
-                log.error("결제 실패: orderId={}, status={}", criteria.getOrderId(), mockPaymentResponse.getStatus());
-                throw new RuntimeException("결제 API 실패");
-            }
-
-
-            /*
-                이벤트 발행
-            */
-            PaymentTransactionResult.Payment result = PaymentTransactionResult.Payment.of(
-                    mockPaymentResponse.getTransactionId(),
-                    mockPaymentResponse.getStatus(),
-                    finalAmount
-            );
-
-            eventPublisher.publishEvent(new PaymentCompletedEvent(criteria, result));
+            eventPublisher.publishEvent(PaymentEvent.RequestPaymentApi.of(
+                    criteria.getOrderId(),criteria.getUserId(),finalAmount,criteria.getCouponId()));
 
         } catch (Exception e) {
-            log.warn("트랜잭션 내 결제 실패, 주문 상태 취소 및 재고 복구 수행");
-
-            try {
-                if (order != null && order.getOrderStatus().equals(OrderStatus.CREATED)) {
-                    log.info("주문 상태 복구 및 재고 복구 시작: orderId={}", criteria.getOrderId());
-
-                    /*
-                        주문 상태 변경
-                    */
-                    orderService.updateOrderStatus(criteria.getOrderId(), OrderStatus.CANCELED);
-
-                    /*
-                        재고 복구
-                    */
-                    OrderInfo.GetOrderItems getOrderItems = orderService.getOrderItemByOrderId(criteria.getOrderId());
-                    stockService.recoveryStock(criteria.toRecoveryStockCommand(getOrderItems));
-
-                    /*
-                        쿠폰 랭킹 복구
-                    */
-
-                    // redisTemplate.opsForZSet().incrementScore(POPULAR_PRODUCTS_KEY, productId, -1);
-
-                    log.info("주문 취소 및 재고 복구 완료");
-                } else {
-                    log.info("이미 취소된 주문입니다. orderId={}", criteria.getOrderId());
-                }
-
-            } catch (Exception recoveryEx) {
-                log.error("회복 중 추가 오류 발생: {}", recoveryEx.getMessage(), recoveryEx);
-            }
-
+            eventPublisher.publishEvent(PaymentEvent.RecoveryOrder.of(criteria.getOrderId()));
             throw new RuntimeException("결제 처리 중 예외 발생", e);
         }
     }
+
 
 
 }

--- a/src/main/java/com/example/demo/application/payment/PaymentTransaction.java
+++ b/src/main/java/com/example/demo/application/payment/PaymentTransaction.java
@@ -11,29 +11,33 @@ import com.example.demo.infra.payment.PaymentMockResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
-
-import static com.example.demo.infra.payment.PaymentPopularScheduler.POPULAR_PRODUCTS_KEY;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class PaymentTransaction {
+
     private final OrderService orderService;
     private final BalanceService balanceService;
     private final MockPaymentService mockPaymentService;
     private final CouponService couponService;
     private final StockService stockService;
     private final RedisTemplate<String, String> redisTemplate;
+    private final ApplicationEventPublisher eventPublisher;
+
 
     @Transactional
-    public PaymentTransactionResult.Payment processPaymentWithTransaction(PaymentCriteria.Payment criteria) {
+    public void processPaymentWithTransaction(PaymentCriteria.Payment criteria) {
         OrderInfo.GetOrder order = null;
         try {
 
-            //주문 조회
+             /*
+                 주문 조회
+             */
+
             order = orderService.getOrderById(criteria.getOrderId());
             long finalAmount = order.getProductTotalPrice();
 
@@ -42,34 +46,51 @@ public class PaymentTransaction {
                 throw new RuntimeException("이미 결제된 주문입니다.");
             }
 
-            //쿠폰사용
+            /*
+                쿠폰사용
+            */
             if (criteria.getCouponId() != null) {
                 couponService.use(criteria.toUseCouponCommand());
                 finalAmount = couponService.calculateDiscountedAmount(finalAmount, criteria.getCouponId());
             }
 
-            // 포인트사용
+            /*
+                포인트사용
+            */
             balanceService.use(criteria.toBalanceUseCommand(finalAmount));
 
-            //주문상태변경
+
+            /*
+                주문상태변경
+            */
             orderService.updateOrderStatus(criteria.getOrderId(), OrderStatus.PAID);
 
-            //외부 API 호출
+            /*
+                외부 API 호출
+            */
             PaymentMockResponse.MockPay mockPaymentResponse = mockPaymentService.callAndValidateMockApi(
                     criteria.toPaymentMockRequest(finalAmount)
             );
 
-            //API 호출 검증
+            /*
+                API 호출 검증
+            */
             if (!"SUCCESS".equals(mockPaymentResponse.getStatus())) {
                 log.error("결제 실패: orderId={}, status={}", criteria.getOrderId(), mockPaymentResponse.getStatus());
                 throw new RuntimeException("결제 API 실패");
             }
 
-            return PaymentTransactionResult.Payment.of(
+
+            /*
+                이벤트 발행
+            */
+            PaymentTransactionResult.Payment result = PaymentTransactionResult.Payment.of(
                     mockPaymentResponse.getTransactionId(),
                     mockPaymentResponse.getStatus(),
                     finalAmount
             );
+
+            eventPublisher.publishEvent(new PaymentCompletedEvent(criteria, result));
 
         } catch (Exception e) {
             log.warn("트랜잭션 내 결제 실패, 주문 상태 취소 및 재고 복구 수행");
@@ -78,15 +99,22 @@ public class PaymentTransaction {
                 if (order != null && order.getOrderStatus().equals(OrderStatus.CREATED)) {
                     log.info("주문 상태 복구 및 재고 복구 시작: orderId={}", criteria.getOrderId());
 
-                    //주문 상태 변경
+                    /*
+                        주문 상태 변경
+                    */
                     orderService.updateOrderStatus(criteria.getOrderId(), OrderStatus.CANCELED);
 
-                    //재고 복구
+                    /*
+                        재고 복구
+                    */
                     OrderInfo.GetOrderItems getOrderItems = orderService.getOrderItemByOrderId(criteria.getOrderId());
                     stockService.recoveryStock(criteria.toRecoveryStockCommand(getOrderItems));
 
-                    //쿠폰 랭킹 복구
-                   // redisTemplate.opsForZSet().incrementScore(POPULAR_PRODUCTS_KEY, productId, -1);
+                    /*
+                        쿠폰 랭킹 복구
+                    */
+
+                    // redisTemplate.opsForZSet().incrementScore(POPULAR_PRODUCTS_KEY, productId, -1);
 
                     log.info("주문 취소 및 재고 복구 완료");
                 } else {

--- a/src/main/java/com/example/demo/application/payment/PaymentTransactionResult.java
+++ b/src/main/java/com/example/demo/application/payment/PaymentTransactionResult.java
@@ -1,0 +1,26 @@
+package com.example.demo.application.payment;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PaymentTransactionResult {
+
+    @Getter
+    public static class Payment {
+        private final String transactionId;
+        private final String status;
+        private final long finalAmount;
+
+        public Payment(String transactionId, String status, long finalAmount) {
+            this.transactionId = transactionId;
+            this.status = status;
+            this.finalAmount = finalAmount;
+        }
+
+        public static Payment of(String transactionId, String status, long finalAmount) {
+            return new Payment(transactionId, status, finalAmount);
+        }
+    }
+}

--- a/src/main/java/com/example/demo/domain/payment/PaymentHistoryService.java
+++ b/src/main/java/com/example/demo/domain/payment/PaymentHistoryService.java
@@ -45,12 +45,7 @@ public class PaymentHistoryService {
                 redisTemplate.opsForZSet().reverseRangeWithScores(POPULAR_PRODUCTS_KEY, 0, 4);
 
         if (zset != null && !zset.isEmpty()) {
-            return zset.stream()
-                    .map(tuple -> new PaymentHistoryInfo.Top5OrdersForCaching(
-                            Long.valueOf(Objects.requireNonNull(tuple.getValue()).toString()),
-                            Objects.requireNonNull(tuple.getScore()).longValue()
-                    ))
-                    .toList();
+            return mapToCachingList(zset);
         }
 
         RLock lock = redissonClient.getLock("lock:popular:top5");
@@ -62,38 +57,29 @@ public class PaymentHistoryService {
             if (isLocked) {
                 zset = redisTemplate.opsForZSet().reverseRangeWithScores(POPULAR_PRODUCTS_KEY, 0, 4);
                 if (zset != null && !zset.isEmpty()) {
-                    return zset.stream()
-                            .map(tuple -> new PaymentHistoryInfo.Top5OrdersForCaching(
-                                    Long.valueOf(Objects.requireNonNull(tuple.getValue()).toString()),
-                                    Objects.requireNonNull(tuple.getScore()).longValue()
-                            ))
-                            .toList();
+                    return mapToCachingList(zset);
                 }
 
+                redisTemplate.delete(POPULAR_PRODUCTS_KEY);
                 List<ResTopOrderFive> popularProducts = paymentHistoryRepository.findTop5OrdersByPaidStatus();
 
                 for (ResTopOrderFive item : popularProducts) {
                     redisTemplate.opsForZSet().add(POPULAR_PRODUCTS_KEY, item.getOrderId(), item.getCount());
                 }
 
-                log.info("[CACHE] 인기 상품 ZSET 캐시 저장 완료");
+                redisTemplate.expire(POPULAR_PRODUCTS_KEY, 10, TimeUnit.MINUTES); // TTL 10분 설정
+                log.info("[CACHE] 인기 상품 ZSET 캐시 재등록 완료");
+
                 return PaymentHistoryInfo.Top5OrdersForCaching.fromResTopList(popularProducts);
             } else {
-                log.warn("[LOCK] 락 획득 실패 - 100ms 후 재시도");
+                log.warn("[LOCK] 락 획득 실패 - 캐시 재시도");
                 Thread.sleep(100);
 
                 zset = redisTemplate.opsForZSet().reverseRangeWithScores(POPULAR_PRODUCTS_KEY, 0, 4);
                 if (zset != null && !zset.isEmpty()) {
-                    log.info("[CACHE] 재시도 후 ZSET 캐시 HIT");
-                    return zset.stream()
-                            .map(tuple -> new PaymentHistoryInfo.Top5OrdersForCaching(
-                                    Long.valueOf(Objects.requireNonNull(tuple.getValue()).toString()),
-                                    Objects.requireNonNull(tuple.getScore()).longValue()
-                            ))
-                            .toList();
+                    return mapToCachingList(zset);
                 } else {
-                    log.error("[CACHE] 캐시 초기화 대기 중에도 ZSET 없음 - 실패 처리");
-                    throw new IllegalStateException("ZSET 캐시 초기화 대기 중 실패");
+                    throw new IllegalStateException("캐시 초기화 대기 중에도 ZSET 없음 - 실패 처리");
                 }
             }
 
@@ -101,7 +87,7 @@ public class PaymentHistoryService {
             Thread.currentThread().interrupt();
             throw new RuntimeException("락 대기 중 인터럽트 발생", e);
         } catch (Exception e) {
-            log.error("[ERROR] 인기 상품 조회 실패 - 원인: {}", e.getMessage(), e);
+            log.error("[ERROR] 인기 상품 조회 실패: {}", e.getMessage(), e);
             throw new RuntimeException("인기 상품 조회 실패", e);
         } finally {
             if (isLocked && lock.isHeldByCurrentThread()) {
@@ -110,7 +96,14 @@ public class PaymentHistoryService {
         }
     }
 
-
+    private List<PaymentHistoryInfo.Top5OrdersForCaching> mapToCachingList(Set<ZSetOperations.TypedTuple<Object>> zset) {
+        return zset.stream()
+                .map(tuple -> new PaymentHistoryInfo.Top5OrdersForCaching(
+                        Long.parseLong(String.valueOf(tuple.getValue())),
+                        tuple.getScore().longValue()
+                ))
+                .toList();
+    }
 
 
 

--- a/src/main/java/com/example/demo/domain/stock/StockService.java
+++ b/src/main/java/com/example/demo/domain/stock/StockService.java
@@ -1,22 +1,26 @@
 package com.example.demo.domain.stock;
 
 import com.example.demo.support.comm.aop.DistributedLock;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
 
 @Service
 @RequiredArgsConstructor
 public class StockService {
     private final StockTransactionService stockTransactionService;
 
-    @DistributedLock(key = "'stock:deduct:' + #command.userId", waitTime = 5, leaseTime = 3)
+    @DistributedLock(key = "'lock:stock:deduct'", waitTime = 5, leaseTime = 3)
     public void deductStock(StockCommand.DeductStock command) {
         stockTransactionService.deductStockWithTransaction(command);
     }
 
-    @Transactional
-    public void recoveryStock(StockCommand.RecoveryStock command){
+    @DistributedLock(key = "'lock:stock:recovery'", waitTime = 5, leaseTime = 3)
+    public void recoveryStock(StockCommand.RecoveryStock command) {
         stockTransactionService.recoveryStockWithTransaction(command);
     }
+
+
+
+
 }

--- a/src/main/java/com/example/demo/domain/stock/StockService.java
+++ b/src/main/java/com/example/demo/domain/stock/StockService.java
@@ -1,58 +1,22 @@
 package com.example.demo.domain.stock;
 
-import com.example.demo.infra.stock.StockJpaRepository;
+import com.example.demo.support.comm.aop.DistributedLock;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.redisson.api.RLock;
-import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
-
-import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
 public class StockService {
-    private final StockJpaRepository stockRepository;
-    private final RedissonClient redissonClient;
     private final StockTransactionService stockTransactionService;
 
+    @DistributedLock(key = "'stock:deduct:' + #command.userId", waitTime = 5, leaseTime = 3)
     public void deductStock(StockCommand.DeductStock command) {
-        String lockKey = "lock:stock:deduct";
-        RLock lock = redissonClient.getLock(lockKey);
-
-        boolean isLocked = false;
-        try {
-            isLocked = lock.tryLock(5, 3, TimeUnit.SECONDS);
-            if (!isLocked) {
-                throw new IllegalStateException("락 획득 실패: 동시 요청 과다");
-            }
-
-            stockTransactionService.deductStockWithTransaction(command);
-
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("락 대기 중 인터럽트 발생", e);
-        } finally {
-            if (isLocked && lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
-        }
+        stockTransactionService.deductStockWithTransaction(command);
     }
 
     @Transactional
     public void recoveryStock(StockCommand.RecoveryStock command){
-        command.getProducts().forEach(product -> {
-            Stock stock = findStockOrThrow(product.getProductId());
-            stock.recovery(product.getQuantity().intValue());
-            stockRepository.save(stock);
-        });
+        stockTransactionService.recoveryStockWithTransaction(command);
     }
-
-    private Stock findStockOrThrow(Long productId) {
-        return stockRepository.findByProductId(productId)
-                .orElseThrow(() -> new RuntimeException(
-                        "해당 상품의 재고가 존재하지 않습니다. productId=" + productId
-                ));
-    }
-
 }

--- a/src/main/java/com/example/demo/domain/stock/StockTransactionService.java
+++ b/src/main/java/com/example/demo/domain/stock/StockTransactionService.java
@@ -14,12 +14,23 @@ public class StockTransactionService {
     @Transactional
     public void deductStockWithTransaction(StockCommand.DeductStock command) {
         command.getProducts().forEach(product -> {
-            Stock stock = stockRepository.findWithPessimisticLock(product.getProductId())
+            Stock stock = stockRepository.findByProductId(product.getProductId())
                     .orElseThrow(() -> new IllegalStateException("재고가 존재하지 않습니다."));
 
             stock.deduct(product.getQuantity().intValue());
             stockRepository.save(stock);
         });
+    }
+
+    @Transactional
+    public void recoveryStockWithTransaction(StockCommand.RecoveryStock command) {
+            command.getProducts().forEach(product -> {
+                Stock stock = stockRepository.findByProductId(product.getProductId())
+                        .orElseThrow(() -> new IllegalStateException("재고가 존재하지 않습니다."));
+
+                stock.recovery(product.getQuantity().intValue());
+                stockRepository.save(stock);
+            });
     }
 
 }

--- a/src/main/java/com/example/demo/infra/payment/PaymentHistoryJdbcRepository.java
+++ b/src/main/java/com/example/demo/infra/payment/PaymentHistoryJdbcRepository.java
@@ -44,12 +44,13 @@ public class PaymentHistoryJdbcRepository {
 
     public List<ResTopOrderFive> findTop5OrdersByPaidStatus() {
         String sql = """
-            SELECT order_id, COUNT(*) AS cnt
-            FROM t1_payment_history
-            WHERE status = 'SUCCESS'
-            GROUP BY order_id
+            SELECT oi.product_id as order_id, SUM(oi.quantity) AS cnt
+            FROM t1_payment_history ph
+            JOIN t1_order_item oi ON ph.order_id = oi.order_id
+            WHERE ph.status = 'SUCCESS'
+            GROUP BY oi.product_id
             ORDER BY cnt DESC
-            LIMIT 5
+            LIMIT 5;
         """;
 
         return jdbcTemplate.query(sql, (rs, rowNum) ->

--- a/src/main/java/com/example/demo/infra/payment/PaymentPopularScheduler.java
+++ b/src/main/java/com/example/demo/infra/payment/PaymentPopularScheduler.java
@@ -35,10 +35,14 @@ public class PaymentPopularScheduler {
                 return;
             }
 
+            redisTemplate.delete(POPULAR_PRODUCTS_KEY);
+
             List<PaymentHistoryInfo.Top5Orders> top5 = paymentHistoryService.getTop5Orders();
             for (PaymentHistoryInfo.Top5Orders order : top5) {
                 redisTemplate.opsForZSet().add(POPULAR_PRODUCTS_KEY, order.getOrderId(), order.getCount());
             }
+
+            redisTemplate.expire(POPULAR_PRODUCTS_KEY, 10, TimeUnit.MINUTES);
 
             log.info("초기 인기 상품 ZSET 등록 완료: {}", Utils.toJson(top5));
 

--- a/src/main/java/com/example/demo/support/comm/aop/DistributedLock.java
+++ b/src/main/java/com/example/demo/support/comm/aop/DistributedLock.java
@@ -1,0 +1,14 @@
+package com.example.demo.support.comm.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+    String key();
+    long waitTime() default 3;
+    long leaseTime() default 5;
+}

--- a/src/main/java/com/example/demo/support/comm/aop/DistributedLockAspect.java
+++ b/src/main/java/com/example/demo/support/comm/aop/DistributedLockAspect.java
@@ -1,0 +1,63 @@
+package com.example.demo.support.comm.aop;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DistributedLockAspect{
+
+    private final RedissonClient redissonClient;
+
+    @Around("@annotation(distributedLock)")
+    public Object around(ProceedingJoinPoint joinPoint, DistributedLock distributedLock) throws Throwable {
+        String key = generateKey(joinPoint, distributedLock.key());
+        RLock lock = redissonClient.getLock(key);
+        boolean isLocked = false;
+
+        try {
+            isLocked = lock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), TimeUnit.SECONDS);
+            if (!isLocked) {
+                throw new IllegalStateException("중복 요청입니다. 잠시 후 다시 시도해주세요.");
+            }
+
+            return joinPoint.proceed();
+
+        } finally {
+            if (isLocked && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+    }
+
+    private String generateKey(ProceedingJoinPoint joinPoint, String keyExpression) {
+        ExpressionParser parser = new SpelExpressionParser();
+        EvaluationContext context = new StandardEvaluationContext();
+
+        Object[] args = joinPoint.getArgs();
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        String[] paramNames = signature.getParameterNames();
+
+        for (int i = 0; i < paramNames.length; i++) {
+            context.setVariable(paramNames[i], args[i]);
+        }
+
+        return parser.parseExpression(keyExpression).getValue(context, String.class);
+    }
+}


### PR DESCRIPTION
### 이벤트 분리
- [96bcce5](https://github.com/jaemin4/cleanJ/pull/12/commits/96bcce56774f2bfae773ebe8b7cbc4c3f0aa1ec0), [58d214b](https://github.com/jaemin4/cleanJ/pull/12/commits/58d214b6c3965322f5c1d38fe657c9edaf82d36a), [eb280de](https://github.com/jaemin4/cleanJ/pull/12/commits/eb280dee7ba508c6be08927a6ef1f6e78de0f643)
 
### MSA 설계

 - 보고서 : https://immediate-guilty-784.notion.site/Step-16-1fba20f91e0d8067a8d8ee0f7abe7f99

### 리뷰 포인트
 - 결제내역 저장 같은 경우에는 실패확률이 낮기 때문에 Retry3번 정도는 괜찮을거 같은데 결제 복구 트랜잭션이나 주문 복구 트랜잭션이 실패했을때 Retry하는 전략은 괜찮을지

